### PR TITLE
refactor: delete `ReactAttr`

### DIFF
--- a/packages/react/src/components/DataTable/TableBody.tsx
+++ b/packages/react/src/components/DataTable/TableBody.tsx
@@ -1,15 +1,15 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
-import { ReactAttr } from '../../types/common';
+import React, { type HTMLAttributes } from 'react';
 
-export interface TableBodyProps extends ReactAttr<HTMLTableSectionElement> {
+export interface TableBodyProps
+  extends HTMLAttributes<HTMLTableSectionElement> {
   /**
    * `polite` Adjust the notification behavior of screen readers
    */

--- a/packages/react/src/components/DataTable/TableCell.tsx
+++ b/packages/react/src/components/DataTable/TableCell.tsx
@@ -1,16 +1,15 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { type HTMLAttributes } from 'react';
 import classNames from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
-import { ReactAttr } from '../../types/common';
 
-export interface TableCellProps extends ReactAttr<HTMLTableCellElement> {
+export interface TableCellProps extends HTMLAttributes<HTMLTableCellElement> {
   /**
    * Pass in children that will be embedded in the table header label
    */

--- a/packages/react/src/components/DataTable/TableContainer.tsx
+++ b/packages/react/src/components/DataTable/TableContainer.tsx
@@ -7,15 +7,14 @@
 
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React, { useMemo } from 'react';
-import { ReactAttr } from '../../types/common';
+import React, { useMemo, type HTMLAttributes } from 'react';
 import { usePrefix } from '../../internal/usePrefix';
 import { useId } from '../../internal/useId';
 import { TableContext } from './TableContext';
 import { Heading, Section } from '../Heading';
 
 export interface TableContainerProps
-  extends Omit<ReactAttr<HTMLDivElement>, 'title'> {
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
   /**
    * Optional description text for the Table
    */

--- a/packages/react/src/components/DataTable/TableExpandHeader.tsx
+++ b/packages/react/src/components/DataTable/TableExpandHeader.tsx
@@ -8,11 +8,10 @@
 import { ChevronRight } from '@carbon/icons-react';
 import cx from 'classnames';
 import PropTypes, { Validator } from 'prop-types';
-import React from 'react';
+import React, { type HTMLAttributes } from 'react';
 import { usePrefix } from '../../internal/usePrefix';
 import deprecate from '../../prop-types/deprecate';
 import requiredIfGivenPropIsTruthy from '../../prop-types/requiredIfGivenPropIsTruthy';
-import { ReactAttr } from '../../types/common';
 
 export type TableExpandHeaderPropsBase = {
   /**
@@ -54,7 +53,7 @@ export type TableExpandHeaderPropsBase = {
    * Hook for when a listener initiates a request to expand the given row
    */
   onExpand?(event: React.MouseEvent<HTMLButtonElement>): void;
-} & ReactAttr<HTMLTableCellElement>;
+} & HTMLAttributes<HTMLTableCellElement>;
 
 export type TableExpandHeaderPropsWithToggle = Omit<
   TableExpandHeaderPropsBase,

--- a/packages/react/src/components/DataTable/TableExpandedRow.tsx
+++ b/packages/react/src/components/DataTable/TableExpandedRow.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,12 +7,12 @@
 
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React, { useRef } from 'react';
+import React, { useRef, type HTMLAttributes } from 'react';
 import TableCell from './TableCell';
 import { usePrefix } from '../../internal/usePrefix';
-import { ReactAttr } from '../../types/common';
 
-export interface TableExpandedRowProps extends ReactAttr<HTMLTableRowElement> {
+export interface TableExpandedRowProps
+  extends HTMLAttributes<HTMLTableRowElement> {
   /**
    * The width of the expanded row's internal cell
    */

--- a/packages/react/src/components/DataTable/TableHeader.tsx
+++ b/packages/react/src/components/DataTable/TableHeader.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,7 +7,12 @@
 
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React, { type MouseEventHandler, useRef, ReactNode } from 'react';
+import React, {
+  useRef,
+  type HTMLAttributes,
+  type MouseEventHandler,
+  type ReactNode,
+} from 'react';
 import {
   ArrowUp as Arrow,
   ArrowsVertical as Arrows,
@@ -16,7 +21,7 @@ import classNames from 'classnames';
 import { sortStates } from './state/sorting';
 import { useId } from '../../internal/useId';
 import { usePrefix } from '../../internal/usePrefix';
-import { TranslateWithId, ReactAttr } from '../../types/common';
+import { TranslateWithId } from '../../types/common';
 import { DataTableSortState } from './state/sortStates';
 
 const defaultScope = 'col';
@@ -64,7 +69,7 @@ const sortDirections: { [key: string]: 'none' | 'ascending' | 'descending' } = {
 };
 
 export interface TableHeaderProps
-  extends ReactAttr<HTMLTableCellElement & HTMLButtonElement>,
+  extends HTMLAttributes<HTMLTableCellElement & HTMLButtonElement>,
     TranslateWithId<
       TableHeaderTranslationKey,
       { header; sortDirection; isSortHeader; sortStates }

--- a/packages/react/src/components/DataTable/TableRow.tsx
+++ b/packages/react/src/components/DataTable/TableRow.tsx
@@ -1,17 +1,16 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { type HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
-import { ReactAttr } from '../../types/common';
 
-export interface TableRowProps extends ReactAttr<HTMLTableRowElement> {
+export interface TableRowProps extends HTMLAttributes<HTMLTableRowElement> {
   /**
    * Specify an optional className to be applied to the container node
    */

--- a/packages/react/src/components/DatePickerInput/DatePickerInput.tsx
+++ b/packages/react/src/components/DatePickerInput/DatePickerInput.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -8,11 +8,15 @@
 import { Calendar, WarningFilled, WarningAltFilled } from '@carbon/icons-react';
 import cx from 'classnames';
 import PropTypes, { ReactElementLike, ReactNodeArray } from 'prop-types';
-import React, { ForwardedRef, ReactNode, useContext } from 'react';
+import React, {
+  useContext,
+  type ForwardedRef,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
 import { usePrefix } from '../../internal/usePrefix';
 import { FormContext } from '../FluidForm';
 import { useId } from '../../internal/useId';
-import { ReactAttr } from '../../types/common';
 import { Text } from '../Text';
 import deprecate from '../../prop-types/deprecate';
 
@@ -29,7 +33,7 @@ export type ReactNodeLike =
 export type func = (...args: any[]) => any;
 
 export interface DatePickerInputProps
-  extends Omit<ReactAttr<HTMLInputElement>, ExcludedAttributes> {
+  extends Omit<HTMLAttributes<HTMLInputElement>, ExcludedAttributes> {
   /**
    * The type of the date picker:
    *

--- a/packages/react/src/components/Dialog/index.tsx
+++ b/packages/react/src/components/Dialog/index.tsx
@@ -1,20 +1,24 @@
 /**
- * Copyright IBM Corp. 2014, 2024
+ * Copyright IBM Corp. 2014, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import PropTypes from 'prop-types';
-import React, { MutableRefObject, useEffect, useRef } from 'react';
+import React, {
+  useEffect,
+  useRef,
+  type HTMLAttributes,
+  type MutableRefObject,
+} from 'react';
 import { usePrefix } from '../../internal/usePrefix';
 import cx from 'classnames';
 import { Close } from '@carbon/icons-react';
 import { IconButton } from '../IconButton';
 import { noopFn } from '../../internal/noopFn';
-import { ReactAttr } from '../../types/common';
 
-export interface DialogProps extends ReactAttr<HTMLDialogElement> {
+export interface DialogProps extends HTMLAttributes<HTMLDialogElement> {
   /**
    * Provide the contents of the Dialog
    */
@@ -173,7 +177,7 @@ unstable__Dialog.propTypes = {
   open: PropTypes.bool,
 };
 
-export interface DialogHeaderProps extends ReactAttr<HTMLDivElement> {
+export interface DialogHeaderProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Provide the contents to be rendered inside of this component
    */
@@ -196,7 +200,7 @@ DialogHeader.propTypes = {
   children: PropTypes.node,
 };
 
-export interface DialogControlsProps extends ReactAttr<HTMLDivElement> {
+export interface DialogControlsProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Provide the contents to be rendered inside of this component
    */
@@ -221,7 +225,7 @@ DialogControls.propTypes = {
   children: PropTypes.node,
 };
 
-export interface DialogCloseButtonProps extends ReactAttr<HTMLDivElement> {
+export interface DialogCloseButtonProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Specify a click handler applied to the IconButton
    */

--- a/packages/react/src/components/Dropdown/Dropdown.Skeleton.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.Skeleton.tsx
@@ -1,18 +1,17 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { type HTMLAttributes } from 'react';
 import cx from 'classnames';
 import { ListBoxSize, PropTypes as ListBoxPropTypes } from '../ListBox';
 import { usePrefix } from '../../internal/usePrefix';
-import { ReactAttr } from '../../types/common';
 
-export interface DropdownSkeletonProps extends ReactAttr<HTMLDivElement> {
+export interface DropdownSkeletonProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Specify an optional className to add.
    */

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -6,16 +6,17 @@
  */
 
 import React, {
-  FocusEvent,
-  ForwardedRef,
   isValidElement,
-  MouseEvent,
-  ReactNode,
   useCallback,
   useContext,
   useEffect,
   useMemo,
   useState,
+  type FocusEvent,
+  type ForwardedRef,
+  type HTMLAttributes,
+  type MouseEvent,
+  type ReactNode,
 } from 'react';
 import {
   useSelect,
@@ -42,7 +43,7 @@ import mergeRefs from '../../tools/mergeRefs';
 import deprecate from '../../prop-types/deprecate';
 import { usePrefix } from '../../internal/usePrefix';
 import { FormContext } from '../FluidForm';
-import { TranslateWithId, ReactAttr } from '../../types/common';
+import { TranslateWithId } from '../../types/common';
 import { useId } from '../../internal/useId';
 import {
   useFloating,
@@ -83,7 +84,7 @@ export interface OnChangeData<ItemType> {
 }
 
 export interface DropdownProps<ItemType>
-  extends Omit<ReactAttr<HTMLDivElement>, ExcludedAttributes>,
+  extends Omit<HTMLAttributes<HTMLDivElement>, ExcludedAttributes>,
     TranslateWithId<ListBoxMenuIconTranslationKey>,
     React.RefAttributes<HTMLDivElement> {
   /**

--- a/packages/react/src/components/FileUploader/FileUploader.Skeleton.tsx
+++ b/packages/react/src/components/FileUploader/FileUploader.Skeleton.tsx
@@ -1,19 +1,19 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { type HTMLAttributes } from 'react';
 import cx from 'classnames';
 import SkeletonText from '../SkeletonText';
 import ButtonSkeleton from '../Button/Button.Skeleton';
 import { usePrefix } from '../../internal/usePrefix';
-import { ReactAttr } from '../../types/common';
 
-export interface FileUploaderSkeletonProps extends ReactAttr<HTMLDivElement> {
+export interface FileUploaderSkeletonProps
+  extends HTMLAttributes<HTMLDivElement> {
   /**
    * Specify an optional className to add.
    */

--- a/packages/react/src/components/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/FileUploader/FileUploader.tsx
@@ -7,17 +7,21 @@
 
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, { useState, ForwardedRef, useImperativeHandle } from 'react';
+import React, {
+  useImperativeHandle,
+  useState,
+  type ForwardedRef,
+  type HTMLAttributes,
+} from 'react';
 import Filename from './Filename';
 import FileUploaderButton from './FileUploaderButton';
 import { ButtonKinds } from '../Button/Button';
 import { keys, matches } from '../../internal/keyboard';
 import { usePrefix } from '../../internal/usePrefix';
-import { ReactAttr } from '../../types/common';
 import { Text } from '../Text';
 import { useId } from '../../internal/useId';
 
-export interface FileUploaderProps extends ReactAttr<HTMLSpanElement> {
+export interface FileUploaderProps extends HTMLAttributes<HTMLSpanElement> {
   /**
    * Specify the types of files that this input should be able to receive
    */

--- a/packages/react/src/components/FileUploader/FileUploaderButton.tsx
+++ b/packages/react/src/components/FileUploader/FileUploaderButton.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,17 +7,16 @@
 
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, type HTMLAttributes } from 'react';
 import { matches, keys } from '../../internal/keyboard';
 import { ButtonKinds } from '../../prop-types/types';
 import uid from '../../tools/uniqueId';
 import { usePrefix } from '../../internal/usePrefix';
 import deprecate from '../../prop-types/deprecate';
-import { ReactAttr } from '../../types/common';
 import { noopFn } from '../../internal/noopFn';
 
 export interface FileUploaderButtonProps
-  extends Omit<ReactAttr<HTMLButtonElement>, 'onChange' | 'tabIndex'> {
+  extends Omit<HTMLAttributes<HTMLButtonElement>, 'onChange' | 'tabIndex'> {
   /**
    * Specify the types of files that this input should be able to receive
    */

--- a/packages/react/src/components/FileUploader/FileUploaderDropContainer.tsx
+++ b/packages/react/src/components/FileUploader/FileUploaderDropContainer.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, type HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { keys, matches } from '../../internal/keyboard';
@@ -13,11 +13,10 @@ import uniqueId from '../../tools/uniqueId';
 import { usePrefix } from '../../internal/usePrefix';
 import { composeEventHandlers } from '../../tools/events';
 import deprecate from '../../prop-types/deprecate';
-import { ReactAttr } from '../../types/common';
 import { noopFn } from '../../internal/noopFn';
 
 export interface FileUploaderDropContainerProps
-  extends Omit<ReactAttr<HTMLButtonElement>, 'tabIndex'> {
+  extends Omit<HTMLAttributes<HTMLButtonElement>, 'tabIndex'> {
   /**
    * Specify the types of files that this input should be able to receive
    */

--- a/packages/react/src/components/FileUploader/FileUploaderItem.tsx
+++ b/packages/react/src/components/FileUploader/FileUploaderItem.tsx
@@ -7,17 +7,21 @@
 
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React, { useLayoutEffect, useRef, useState } from 'react';
+import React, {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type HTMLAttributes,
+} from 'react';
 import Filename from './Filename';
 import { keys, matches } from '../../internal/keyboard';
 import uid from '../../tools/uniqueId';
 import { usePrefix } from '../../internal/usePrefix';
-import { ReactAttr } from '../../types/common';
 import { noopFn } from '../../internal/noopFn';
 import { Text } from '../Text';
 import { Tooltip } from '../Tooltip';
 
-export interface FileUploaderItemProps extends ReactAttr<HTMLSpanElement> {
+export interface FileUploaderItemProps extends HTMLAttributes<HTMLSpanElement> {
   /**
    * Error message body for an invalid file upload
    */

--- a/packages/react/src/components/FileUploader/Filename.tsx
+++ b/packages/react/src/components/FileUploader/Filename.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,16 +7,16 @@
 
 import { Close, WarningFilled, CheckmarkFilled } from '@carbon/icons-react';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { type HTMLAttributes } from 'react';
 import Loading from '../Loading';
 import { usePrefix } from '../../internal/usePrefix';
-import { ReactAttr } from '../../types/common';
+
 export type FilenameStatus = 'edit' | 'complete' | 'uploading';
 
 type SVGAttr = React.SVGAttributes<React.ReactSVGElement>;
 
 export interface FilenameProps
-  extends Omit<ReactAttr & SVGAttr, 'tabIndex' | 'type'> {
+  extends Omit<HTMLAttributes<HTMLElement> & SVGAttr, 'tabIndex' | 'type'> {
   /**
    * Specify an id that describes the error to be read by screen readers when the filename is invalid
    */

--- a/packages/react/src/components/FluidForm/FluidForm.tsx
+++ b/packages/react/src/components/FluidForm/FluidForm.tsx
@@ -1,19 +1,18 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { type HTMLAttributes } from 'react';
 import classnames from 'classnames';
 import Form from '../Form';
 import { FormContext } from './FormContext';
 import { usePrefix } from '../../internal/usePrefix';
-import { ReactAttr } from '../../types/common';
 
-export type FluidFormProps = ReactAttr<HTMLFormElement>;
+export type FluidFormProps = HTMLAttributes<HTMLFormElement>;
 
 const FluidForm: React.FC<FluidFormProps> = ({
   className,

--- a/packages/react/src/components/FormGroup/FormGroup.tsx
+++ b/packages/react/src/components/FormGroup/FormGroup.tsx
@@ -1,17 +1,16 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { type HTMLAttributes } from 'react';
 import cx from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
-import { ReactAttr } from '../../types/common';
 
-export interface FormGroupProps extends ReactAttr<HTMLFieldSetElement> {
+export interface FormGroupProps extends HTMLAttributes<HTMLFieldSetElement> {
   /**
    * Provide the children form elements to be rendered inside of the <fieldset>
    */

--- a/packages/react/src/components/Grid/GridContext.tsx
+++ b/packages/react/src/components/Grid/GridContext.tsx
@@ -1,12 +1,12 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import PropTypes from 'prop-types';
-import * as React from 'react';
+import React from 'react';
 
 export type GridMode = 'flexbox' | 'css-grid';
 

--- a/packages/react/src/components/ListBox/ListBox.tsx
+++ b/packages/react/src/components/ListBox/ListBox.tsx
@@ -1,18 +1,23 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import cx from 'classnames';
-import React, { type KeyboardEvent, type MouseEvent, useContext } from 'react';
+import React, {
+  useContext,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type MouseEvent,
+} from 'react';
 import PropTypes from 'prop-types';
 import deprecate from '../../prop-types/deprecate';
 import { ListBoxType, ListBoxSize } from './ListBoxPropTypes';
 import { usePrefix } from '../../internal/usePrefix';
 import { FormContext } from '../FluidForm';
-import { ForwardRefReturn, ReactAttr } from '../../types/common';
+import { ForwardRefReturn } from '../../types/common';
 
 const handleOnKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
   if (event.keyCode === 27) {
@@ -28,7 +33,7 @@ const handleClick = (event: MouseEvent<HTMLDivElement>) => {
 type ExcludedAttributes = 'onKeyDown' | 'onKeyPress' | 'ref';
 
 export interface ListBoxProps
-  extends Omit<ReactAttr<HTMLDivElement>, ExcludedAttributes> {
+  extends Omit<HTMLAttributes<HTMLDivElement>, ExcludedAttributes> {
   /**
    * Specify whether the ListBox is currently disabled
    */

--- a/packages/react/src/components/ListBox/ListBoxField.tsx
+++ b/packages/react/src/components/ListBox/ListBoxField.tsx
@@ -1,19 +1,19 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { type HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import { usePrefix } from '../../internal/usePrefix';
-import { ReactAttr } from '../../types/common';
 
+// TODO: When can this code be deleted?
 // No longer used, left export for backward-compatibility
 export const translationIds = {};
 
-export interface ListBoxFieldProps extends ReactAttr<HTMLDivElement> {
+export interface ListBoxFieldProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Specify if the parent <ListBox> is disabled
    */

--- a/packages/react/src/components/ListBox/ListBoxMenu.tsx
+++ b/packages/react/src/components/ListBox/ListBoxMenu.tsx
@@ -1,20 +1,20 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { ForwardedRef } from 'react';
+import React, { type ForwardedRef, type HTMLAttributes } from 'react';
 import { usePrefix } from '../../internal/usePrefix';
 import PropTypes from 'prop-types';
 import ListBoxMenuItem from './ListBoxMenuItem';
-import { ForwardRefReturn, ReactAttr } from '../../types/common';
+import { ForwardRefReturn } from '../../types/common';
 
 type ExcludedAttributes = 'id';
 
 export interface ListBoxMenuProps
-  extends Omit<ReactAttr<HTMLUListElement>, ExcludedAttributes> {
+  extends Omit<HTMLAttributes<HTMLUListElement>, ExcludedAttributes> {
   children?: any;
 
   /**

--- a/packages/react/src/components/ListBox/ListBoxMenuItem.tsx
+++ b/packages/react/src/components/ListBox/ListBoxMenuItem.tsx
@@ -7,18 +7,19 @@
 
 import cx from 'classnames';
 import React, {
-  ForwardedRef,
   forwardRef,
-  ReactNode,
   useEffect,
   useRef,
   useState,
+  type ForwardedRef,
+  type HTMLAttributes,
   type MutableRefObject,
+  type ReactNode,
   type Ref,
 } from 'react';
 import PropTypes from 'prop-types';
 import { usePrefix } from '../../internal/usePrefix';
-import { ForwardRefReturn, ReactAttr } from '../../types/common';
+import { ForwardRefReturn } from '../../types/common';
 import { useMergedRefs } from '../../internal/useMergedRefs';
 
 /**
@@ -55,7 +56,7 @@ const useIsTruncated = <T extends HTMLElement>(
   return { isTruncated, ref: mergedRef };
 };
 
-export interface ListBoxMenuItemProps extends ReactAttr<HTMLLIElement> {
+export interface ListBoxMenuItemProps extends HTMLAttributes<HTMLLIElement> {
   /**
    * Specify any children nodes that should be rendered inside of the ListBox
    * Menu Item

--- a/packages/react/src/components/Loading/Loading.tsx
+++ b/packages/react/src/components/Loading/Loading.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,12 +7,11 @@
 
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { type HTMLAttributes } from 'react';
 import { usePrefix } from '../../internal/usePrefix';
 import deprecate from '../../prop-types/deprecate';
-import { ReactAttr } from '../../types/common';
 
-export interface LoadingProps extends ReactAttr<HTMLDivElement> {
+export interface LoadingProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Specify whether you want the loading indicator to be spinning or not
    */

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -10,6 +10,7 @@ import React, {
   useEffect,
   useRef,
   useState,
+  type HTMLAttributes,
   type ReactNode,
   type Ref,
 } from 'react';
@@ -32,7 +33,6 @@ import { keys, match } from '../../internal/keyboard';
 import { IconButton } from '../IconButton';
 import { noopFn } from '../../internal/noopFn';
 import { Text } from '../Text';
-import { ReactAttr } from '../../types/common';
 import { InlineLoadingStatus } from '../InlineLoading/InlineLoading';
 import { useFeatureFlag } from '../FeatureFlags';
 import { composeEventHandlers } from '../../tools/events';
@@ -50,7 +50,7 @@ export interface ModalSecondaryButton {
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
-export interface ModalProps extends ReactAttr<HTMLDivElement> {
+export interface ModalProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Specify whether the Modal is displaying an alert, error or warning
    * Should go hand in hand with the danger prop.
@@ -396,7 +396,7 @@ const Modal = React.forwardRef(function Modal(
         }
       : {};
 
-  const alertDialogProps: ReactAttr<HTMLDivElement> = {};
+  const alertDialogProps: HTMLAttributes<HTMLDivElement> = {};
   if (alert && passiveModal) {
     alertDialogProps.role = 'alert';
   }

--- a/packages/react/src/components/TextInput/ControlledPasswordInput.tsx
+++ b/packages/react/src/components/TextInput/ControlledPasswordInput.tsx
@@ -1,11 +1,11 @@
 /**
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useRef } from 'react';
+import React, { type HTMLAttributes } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { View, ViewOff, WarningFilled } from '@carbon/icons-react';
@@ -14,13 +14,12 @@ import { warning } from '../../internal/warning';
 import deprecate from '../../prop-types/deprecate';
 import { usePrefix } from '../../internal/usePrefix';
 import { useId } from '../../internal/useId';
-import { ReactAttr } from '../../types/common';
 import { noopFn } from '../../internal/noopFn';
 
 let didWarnAboutDeprecation = false;
 
 export interface ControlledPasswordInputProps
-  extends ReactAttr<HTMLInputElement> {
+  extends HTMLAttributes<HTMLInputElement> {
   /**
    * Provide a custom className that is applied directly to the underlying
    * `<input>` node

--- a/packages/react/src/components/TileGroup/TileGroup.tsx
+++ b/packages/react/src/components/TileGroup/TileGroup.tsx
@@ -1,21 +1,20 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import PropTypes from 'prop-types';
-import React, { ReactNode, useState } from 'react';
+import React, { useState, type HTMLAttributes, type ReactNode } from 'react';
 import RadioTile from '../RadioTile';
 import { usePrefix } from '../../internal/usePrefix';
-import { ReactAttr } from '../../types/common';
 import { noopFn } from '../../internal/noopFn';
 
 type ExcludedAttributes = 'onChange';
 
 export interface TileGroupProps
-  extends Omit<ReactAttr<HTMLFieldSetElement>, ExcludedAttributes> {
+  extends Omit<HTMLAttributes<HTMLFieldSetElement>, ExcludedAttributes> {
   /**
    * Provide a collection of <RadioTile> components to render in the group
    */

--- a/packages/react/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,16 +7,16 @@
 
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { type HTMLAttributes } from 'react';
 import { usePrefix } from '../../internal/usePrefix';
 import deprecate from '../../prop-types/deprecate';
-import { ForwardRefReturn, ReactAttr } from '../../types/common';
+import { ForwardRefReturn } from '../../types/common';
 import { WarningFilled, WarningAltFilled } from '@carbon/icons-react';
 
 type ExcludedAttributes = 'id' | 'value';
 
 export interface TimePickerProps
-  extends Omit<ReactAttr<HTMLInputElement>, ExcludedAttributes> {
+  extends Omit<HTMLAttributes<HTMLInputElement>, ExcludedAttributes> {
   /**
    * Pass in the children that will be rendered next to the form control
    */

--- a/packages/react/src/tools/wrapComponent.ts
+++ b/packages/react/src/tools/wrapComponent.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,9 +7,8 @@
 
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { type HTMLAttributes } from 'react';
 import { usePrefix } from '../internal/usePrefix';
-import { ReactAttr } from '../types/common';
 
 type HTMLTagName = keyof HTMLElementTagNameMap;
 
@@ -28,7 +27,7 @@ const wrapComponent = <T extends HTMLTagName>({
   className: getClassName,
   type,
 }: WrapComponentArgs<T>): ((
-  props: ReactAttr<T>
+  props: HTMLAttributes<T>
 ) => React.ReactElement<any>) => {
   /**
    *
@@ -56,7 +55,7 @@ const wrapComponent = <T extends HTMLTagName>({
     className: PropTypes.string,
   };
 
-  return Component as (props: ReactAttr<T>) => React.ReactElement<any>;
+  return Component as (props: HTMLAttributes<T>) => React.ReactElement<any>;
 };
 
 export default wrapComponent;

--- a/packages/react/src/types/common.ts
+++ b/packages/react/src/types/common.ts
@@ -1,13 +1,9 @@
 /**
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
-import * as React from 'react';
-
-export type ReactAttr<T = HTMLElement> = React.HTMLAttributes<T>;
 
 export type ForwardRefProps<T, P = unknown> = React.PropsWithoutRef<
   React.PropsWithChildren<P>


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/19111

Deleted `ReactAttr`.

#### Changelog

**Changed**

- Changed React namespace imports to default imports.

**Removed**

- Deleted `ReactAttr`.

#### Testing / Reviewing

Check for type errors in files.

I left a `TODO` with a question that hopefully someone can answer.