### PR TITLE
feat: add prop-types to `FluidDatePickerInput`

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -10000,6 +10000,77 @@ Map {
   },
   "unstable__FluidDatePickerInput" => Object {
     "$$typeof": Symbol(react.forward_ref),
+    "propTypes": Object {
+      "datePickerType": Object {
+        "args": Array [
+          Array [
+            "simple",
+            "single",
+            "range",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "decorator": Object {
+        "type": "node",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "helperText": Object {
+        "type": "node",
+      },
+      "hideLabel": Object {
+        "type": "bool",
+      },
+      "id": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "invalid": Object {
+        "type": "bool",
+      },
+      "invalidText": Object {
+        "type": "node",
+      },
+      "labelText": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+      "onChange": Object {
+        "type": "func",
+      },
+      "onClick": Object {
+        "type": "func",
+      },
+      "pattern": [Function],
+      "placeholder": Object {
+        "type": "string",
+      },
+      "readOnly": Object {
+        "type": "bool",
+      },
+      "size": Object {
+        "args": Array [
+          Array [
+            "sm",
+            "md",
+            "lg",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "slug": [Function],
+      "type": Object {
+        "type": "string",
+      },
+      "warn": Object {
+        "type": "bool",
+      },
+      "warnText": Object {
+        "type": "node",
+      },
+    },
     "render": [Function],
   },
   "unstable__FluidDatePickerSkeleton" => Object {

--- a/packages/react/src/components/FluidDatePickerInput/FluidDatePickerInput.tsx
+++ b/packages/react/src/components/FluidDatePickerInput/FluidDatePickerInput.tsx
@@ -1,23 +1,24 @@
 /**
- * Copyright IBM Corp. 2022
+ * Copyright IBM Corp. 2022, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 import DatePickerInput, { DatePickerInputProps } from '../DatePickerInput';
 import { FormContext } from '../FluidForm/FormContext';
 
-const FluidDatePickerInput = React.forwardRef(function FluidDatePickerInput(
-  { ...other }: DatePickerInputProps,
-  ref: React.Ref<HTMLDivElement>
-) {
+const frFn = forwardRef<HTMLDivElement, DatePickerInputProps>;
+
+const FluidDatePickerInput = frFn((props, ref) => {
   return (
     <FormContext.Provider value={{ isFluid: true }}>
-      <DatePickerInput ref={ref} {...other} />
+      <DatePickerInput ref={ref} {...props} />
     </FormContext.Provider>
   );
 });
+
+FluidDatePickerInput.propTypes = DatePickerInput.propTypes;
 
 export default FluidDatePickerInput;


### PR DESCRIPTION
Partially addresses https://github.com/carbon-design-system/carbon/issues/19144

Added prop-types to `FluidDatePickerInput`.

#### Changelog

**New**

- Added prop-types to `FluidDatePickerInput`.

**Changed**

- Updated `FluidDatePickerInput`'s types to use generics.

#### Testing / Reviewing

```sh
yarn test packages/react
```