### PR TITLE
fix: use singular clear label for one selected item

### DIFF
--- a/packages/react/src/components/ListBox/ListBoxSelection.tsx
+++ b/packages/react/src/components/ListBox/ListBoxSelection.tsx
@@ -56,6 +56,8 @@ const translationIds = {
 
 type TranslationKey = keyof typeof translationIds;
 
+// TODO: Should these translations be more consistent? For example, should
+// `clear.all` be "Clear selected items" instead of "Clear all selected items"?
 const defaultTranslations: Record<TranslationKey, string> = {
   [translationIds['clear.all']]: 'Clear all selected items',
   [translationIds['clear.selection']]: 'Clear selected item',
@@ -79,9 +81,11 @@ const ListBoxSelection = ({
   readOnly,
 }: ListBoxSelectionProps) => {
   const prefix = usePrefix();
+  const hasSelectionCount = typeof selectionCount !== 'undefined';
+  const hasMultipleSelections = (selectionCount ?? 0) > 1;
   const className = cx(`${prefix}--list-box__selection`, {
-    [`${prefix}--tag--filter`]: selectionCount,
-    [`${prefix}--list-box__selection--multi`]: selectionCount,
+    [`${prefix}--tag--filter`]: hasSelectionCount,
+    [`${prefix}--list-box__selection--multi`]: hasSelectionCount,
   });
   const handleOnClick = (event: MouseEvent<HTMLDivElement>) => {
     event.stopPropagation();
@@ -93,7 +97,9 @@ const ListBoxSelection = ({
       onClearSelection(event);
     }
   };
-  const description = selectionCount ? t('clear.all') : t('clear.selection');
+  const description = hasMultipleSelections
+    ? t('clear.all')
+    : t('clear.selection');
   const tagClasses = cx(
     `${prefix}--tag`,
     `${prefix}--tag--filter`,
@@ -104,7 +110,7 @@ const ListBoxSelection = ({
   );
 
   /* eslint-disable jsx-a11y/click-events-have-key-events */
-  return selectionCount ? (
+  return hasSelectionCount ? (
     <div className={tagClasses}>
       <span className={`${prefix}--tag__label`} title={`${selectionCount}`}>
         {selectionCount}
@@ -114,7 +120,7 @@ const ListBoxSelection = ({
         tabIndex={-1}
         className={`${prefix}--tag__close-icon`}
         onClick={handleOnClick}
-        aria-label={t('clear.all')}
+        aria-label={description}
         title={description}
         aria-disabled={readOnly ? true : undefined}>
         <Close />
@@ -128,7 +134,6 @@ const ListBoxSelection = ({
       onClick={handleOnClick}
       aria-label={description}
       title={description}>
-      {selectionCount}
       <Close />
     </div>
   );

--- a/packages/react/src/components/ListBox/__tests__/ListBoxSelection-test.js
+++ b/packages/react/src/components/ListBox/__tests__/ListBoxSelection-test.js
@@ -33,7 +33,7 @@ describe('ListBoxSelection', () => {
     expect(screen.getByLabelText('test-clear-selection')).toBeInTheDocument();
   });
 
-  it('should render a clear all button if `selectionCount` is provided', () => {
+  it('should render a clear all button if `selectionCount` is greater than 1', () => {
     render(
       <ListBox.Selection
         selectionCount={10}
@@ -42,6 +42,18 @@ describe('ListBoxSelection', () => {
       />
     );
     expect(screen.getByLabelText('test-clear-all')).toBeInTheDocument();
+  });
+
+  it('should render a clear button if `selectionCount` is 1', () => {
+    render(
+      <ListBox.Selection
+        selectionCount={1}
+        clearSelection={jest.fn()}
+        translateWithId={translateWithId}
+      />
+    );
+    expect(screen.getByLabelText('test-clear-selection')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
   });
 
   it('should call `clearSelection` when the clear button is clicked', async () => {

--- a/packages/react/src/components/ListBox/next/ListBoxSelection.tsx
+++ b/packages/react/src/components/ListBox/next/ListBoxSelection.tsx
@@ -25,6 +25,8 @@ const translationIds = {
 
 type TranslationKey = keyof typeof translationIds;
 
+// TODO: Should these translations be more consistent? For example, should
+// `clear.all` be "Clear selected items" instead of "Clear all selected items"?
 const defaultTranslations: Record<TranslationKey, string> = {
   [translationIds['clear.all']]: 'Clear all selected items',
   [translationIds['clear.selection']]: 'Clear selected item',
@@ -92,11 +94,15 @@ function ListBoxSelection({
   ...rest
 }: ListBoxSelectionProps) {
   const prefix = usePrefix();
+  const hasSelectionCount = typeof selectionCount !== 'undefined';
+  const hasMultipleSelections = (selectionCount ?? 0) > 1;
   const className = cx(`${prefix}--list-box__selection`, {
-    [`${prefix}--tag--filter`]: selectionCount,
-    [`${prefix}--list-box__selection--multi`]: selectionCount,
+    [`${prefix}--tag--filter`]: hasSelectionCount,
+    [`${prefix}--list-box__selection--multi`]: hasSelectionCount,
   });
-  const description = selectionCount ? t('clear.all') : t('clear.selection');
+  const description = hasMultipleSelections
+    ? t('clear.all')
+    : t('clear.selection');
   const tagClasses = cx(
     `${prefix}--tag`,
     `${prefix}--tag--filter`,
@@ -117,7 +123,7 @@ function ListBoxSelection({
     }
   }
 
-  if (selectionCount) {
+  if (hasSelectionCount) {
     return (
       <div className={tagClasses}>
         <span

--- a/packages/react/src/components/MultiSelect/__tests__/FilterableMultiSelect-test.js
+++ b/packages/react/src/components/MultiSelect/__tests__/FilterableMultiSelect-test.js
@@ -877,7 +877,7 @@ describe('FilterableMultiSelect', () => {
     await waitForPosition();
 
     const clearButton = screen.getByRole('button', {
-      name: /Clear all selected items/i,
+      name: 'Clear selected item',
     });
     await user.click(clearButton);
 
@@ -900,7 +900,7 @@ describe('FilterableMultiSelect', () => {
 
     // Remove all selected items
     const clearButton = screen.getByRole('button', {
-      name: /Clear all selected items/i,
+      name: 'Clear all selected items',
     });
     await user.click(clearButton);
 
@@ -918,7 +918,7 @@ describe('FilterableMultiSelect', () => {
     await waitForPosition();
 
     // Get the selected item element (the tag/chip showing the selection)
-    const selectionElement = screen.getByLabelText('Clear all selected items');
+    const selectionElement = screen.getByLabelText('Clear selected item');
     await userEvent.type(selectionElement, '{Backspace}');
 
     expect(mockProps.onChange).toHaveBeenCalledWith({ selectedItems: [] });
@@ -934,7 +934,7 @@ describe('FilterableMultiSelect', () => {
     );
     await waitForPosition();
 
-    const selectionElement = screen.getByLabelText('Clear all selected items');
+    const selectionElement = screen.getByLabelText('Clear selected item');
     await userEvent.type(selectionElement, '{Delete}');
 
     expect(mockProps.onChange).toHaveBeenCalledWith({ selectedItems: [] });
@@ -978,7 +978,7 @@ describe('FilterableMultiSelect', () => {
     );
     await waitForPosition();
 
-    const clearButton = screen.getByLabelText('Clear all selected items');
+    const clearButton = screen.getByLabelText('Clear selected item');
     await userEvent.click(clearButton);
 
     expect(mockProps.onChange).toHaveBeenCalledWith({ selectedItems: [] });

--- a/packages/react/src/components/MultiSelect/__tests__/MultiSelect-test.js
+++ b/packages/react/src/components/MultiSelect/__tests__/MultiSelect-test.js
@@ -391,17 +391,17 @@ describe('MultiSelect', () => {
 
     expect(
       // eslint-disable-next-line testing-library/no-node-access
-      document.querySelector('[aria-label="Clear all selected items"]')
+      document.querySelector('[aria-label="Clear selected item"]')
     ).toBeTruthy();
 
     await userEvent.click(
       // eslint-disable-next-line testing-library/no-node-access
-      document.querySelector('[aria-label="Clear all selected items"]')
+      document.querySelector('[aria-label="Clear selected item"]')
     );
 
     expect(
       // eslint-disable-next-line testing-library/no-node-access
-      document.querySelector('[aria-label="Clear all selected items"]')
+      document.querySelector('[aria-label="Clear selected item"]')
     ).toBeFalsy();
   });
 
@@ -419,7 +419,7 @@ describe('MultiSelect', () => {
 
     const combobox = screen.getByRole('combobox');
     expect(
-      screen.getByRole('button', { name: 'Clear all selected items' })
+      screen.getByRole('button', { name: 'Clear selected item' })
     ).toBeInTheDocument();
 
     await userEvent.click(combobox);
@@ -427,7 +427,7 @@ describe('MultiSelect', () => {
     await userEvent.keyboard('[Delete]');
 
     expect(
-      screen.queryByRole('button', { name: 'Clear all selected items' })
+      screen.queryByRole('button', { name: 'Clear selected item' })
     ).not.toBeInTheDocument();
     expect(screen.getByLabelText('all items have been cleared')).toBeVisible();
   });


### PR DESCRIPTION
No issue.

Used a singular clear label for one selected item.

### Changelog

**Changed**

- Used a singular clear label for one selected item.

#### Testing / Reviewing

```sh
yarn test packages/react
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
